### PR TITLE
Fix elementary OS link

### DIFF
--- a/about.html
+++ b/about.html
@@ -108,7 +108,7 @@
     <li><a href="https://github.com/WeAreROLI/JUCE">Juce</a> by ROLI Ltd.</li>
     <li><a href="https://github.com/cameron314/concurrentqueue">MoodyCamel</a> by Cameron Desrochers</li>
     <li><a href="https://rsms.me/inter/">Inter</a> font by Rasmus Andersson</li>
-    <li> Design inspired by the <a href="https://plugdata.org/elementary.io/">elementaryOS</a> project</li>
+    <li> Design inspired by the <a href="https://elementary.io/">elementaryOS</a> project</li>
     <li><a href="https://github.com/Musicoll/Kiwi">Kiwi</a> by Eliott Paris, Pierre Guillot and Jean Millot</li>
     <li><a href="http://lv2plug.in/">LV2 PlugIn Technology</a> by Steve Harris, David Robillard and others</li>
     <li><a href="https://www.steinberg.net/en/company/technologies/vst3.html">VST PlugIn Technology</a> by Steinberg


### PR DESCRIPTION
Previously went to https://plugdata.org/elementary.io, which doesn't exist, replaced with the actual address of https://elementary.io